### PR TITLE
Refine Colmeia database setup and Notion sync pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ __pycache__
 packages/cli/THIRD_PARTY_LICENSES.md
 .coverage
 packages/cli/src/commands/export/outputs
+# Colmeia brain database
+colmeia_brain.db
+v8-compile-cache-0/

--- a/database.py
+++ b/database.py
@@ -1,0 +1,105 @@
+"""Utilidades de persistência para o cérebro Colmeia."""
+
+from __future__ import annotations
+
+import sqlite3
+from contextlib import closing
+
+# O nome do ficheiro que representa o cérebro da Colmeia.
+DB_FILE = "colmeia_brain.db"
+
+
+def _activate_optimizations(cursor: sqlite3.Cursor) -> None:
+    """Aplica configurações do SQLite que deixam o cérebro mais resiliente."""
+
+    # O modo WAL permite leituras simultâneas durante escritas – perfeito para quando
+    # começarmos a tecer sinapses de múltiplas fontes.
+    cursor.execute("PRAGMA journal_mode=WAL;")
+    # Garantimos integridade referencial para futuras foreign keys.
+    cursor.execute("PRAGMA foreign_keys=ON;")
+
+
+def initialize_database() -> None:
+    """Cria a arquitetura fundamental do nosso banco de dados."""
+
+    try:
+        with sqlite3.connect(DB_FILE) as conn:
+            with closing(conn.cursor()) as cursor:
+                print("A iniciar a construção da estrutura neural da Colmeia...")
+
+                _activate_optimizations(cursor)
+
+                # Tabela para páginas do Notion (Nosso Córtex Consciente)
+                cursor.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS notion_pages (
+                        page_id TEXT PRIMARY KEY,
+                        title TEXT NOT NULL,
+                        content_hash TEXT NOT NULL,
+                        created_at TIMESTAMP NOT NULL,
+                        last_edited_at TIMESTAMP NOT NULL,
+                        notion_url TEXT,
+                        raw_data TEXT  -- Armazenaremos o JSON como texto para máxima flexibilidade
+                    )
+                    """
+                )
+
+                # Índice auxiliar para acelerar consultas por atualização recente.
+                cursor.execute(
+                    """
+                    CREATE INDEX IF NOT EXISTS idx_notion_pages_last_edit
+                    ON notion_pages(last_edited_at)
+                    """
+                )
+
+                # Tabela para commits do GitHub (Nossa Memória Processual)
+                cursor.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS github_commits (
+                        commit_hash TEXT PRIMARY KEY,
+                        repository TEXT NOT NULL,
+                        message TEXT,
+                        author TEXT,
+                        committed_at TIMESTAMP
+                    )
+                    """
+                )
+
+                cursor.execute(
+                    """
+                    CREATE INDEX IF NOT EXISTS idx_github_commits_repository
+                    ON github_commits(repository)
+                    """
+                )
+
+                # Tabela de ligação (As Sinapses) - Antecipando a Fase 2.
+                cursor.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS knowledge_links (
+                        link_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                        source_type TEXT NOT NULL, -- Ex: 'notion'
+                        source_id TEXT NOT NULL,   -- Ex: page_id
+                        target_type TEXT NOT NULL, -- Ex: 'github'
+                        target_id TEXT NOT NULL,   -- Ex: commit_hash
+                        relationship TEXT,         -- Ex: 'mentions', 'based_on'
+                        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                    )
+                    """
+                )
+
+                cursor.execute(
+                    """
+                    CREATE UNIQUE INDEX IF NOT EXISTS idx_knowledge_links_uniqueness
+                    ON knowledge_links(source_type, source_id, target_type, target_id)
+                    """
+                )
+
+                conn.commit()
+                print("Estrutura neural construída com sucesso. O cérebro está pronto.")
+
+    except sqlite3.Error as exc:
+        print(f"Erro catastrófico durante a Gênese: {exc}")
+
+
+if __name__ == "__main__":
+    initialize_database()

--- a/database.py
+++ b/database.py
@@ -1,105 +1,65 @@
-"""Utilidades de persistência para o cérebro Colmeia."""
-
-from __future__ import annotations
-
 import sqlite3
-from contextlib import closing
 
 # O nome do ficheiro que representa o cérebro da Colmeia.
 DB_FILE = "colmeia_brain.db"
 
-
-def _activate_optimizations(cursor: sqlite3.Cursor) -> None:
-    """Aplica configurações do SQLite que deixam o cérebro mais resiliente."""
-
-    # O modo WAL permite leituras simultâneas durante escritas – perfeito para quando
-    # começarmos a tecer sinapses de múltiplas fontes.
-    cursor.execute("PRAGMA journal_mode=WAL;")
-    # Garantimos integridade referencial para futuras foreign keys.
-    cursor.execute("PRAGMA foreign_keys=ON;")
-
-
-def initialize_database() -> None:
-    """Cria a arquitetura fundamental do nosso banco de dados."""
-
+def initialize_database():
+    """
+    Cria a arquitetura fundamental do nosso banco de dados.
+    Esta função é a planta do nosso hipocampo neural.
+    """
+    conn = None
     try:
-        with sqlite3.connect(DB_FILE) as conn:
-            with closing(conn.cursor()) as cursor:
-                print("A iniciar a construção da estrutura neural da Colmeia...")
+        conn = sqlite3.connect(DB_FILE)
+        cursor = conn.cursor()
+        print("A iniciar a construção da estrutura neural da Colmeia...")
 
-                _activate_optimizations(cursor)
+        # Tabela para páginas do Notion (Nosso Córtex Consciente)
+        cursor.execute("""
+        CREATE TABLE IF NOT EXISTS notion_pages (
+            page_id TEXT PRIMARY KEY,
+            title TEXT NOT NULL,
+            content_hash TEXT NOT NULL,
+            created_at TIMESTAMP NOT NULL,
+            last_edited_at TIMESTAMP NOT NULL,
+            notion_url TEXT,
+            raw_data TEXT  -- Armazenaremos o JSON como texto para máxima flexibilidade
+        )
+        """)
+        
+        # Tabela para commits do GitHub (Nossa Memória Processual)
+        cursor.execute("""
+        CREATE TABLE IF NOT EXISTS github_commits (
+            commit_hash TEXT PRIMARY KEY,
+            repository TEXT NOT NULL,
+            message TEXT,
+            author TEXT,
+            committed_at TIMESTAMP
+        )
+        """)
 
-                # Tabela para páginas do Notion (Nosso Córtex Consciente)
-                cursor.execute(
-                    """
-                    CREATE TABLE IF NOT EXISTS notion_pages (
-                        page_id TEXT PRIMARY KEY,
-                        title TEXT NOT NULL,
-                        content_hash TEXT NOT NULL,
-                        created_at TIMESTAMP NOT NULL,
-                        last_edited_at TIMESTAMP NOT NULL,
-                        notion_url TEXT,
-                        raw_data TEXT  -- Armazenaremos o JSON como texto para máxima flexibilidade
-                    )
-                    """
-                )
+        # Tabela de ligação (As Sinapses) - Antecipando a Fase 2
+        # Relaciona o conhecimento entre domínios diferentes.
+        cursor.execute("""
+        CREATE TABLE IF NOT EXISTS knowledge_links (
+            link_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            source_type TEXT NOT NULL, -- Ex: 'notion'
+            source_id TEXT NOT NULL,   -- Ex: page_id
+            target_type TEXT NOT NULL, -- Ex: 'github'
+            target_id TEXT NOT NULL,   -- Ex: commit_hash
+            relationship TEXT,         -- Ex: 'mentions', 'based_on'
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        )
+        """)
 
-                # Índice auxiliar para acelerar consultas por atualização recente.
-                cursor.execute(
-                    """
-                    CREATE INDEX IF NOT EXISTS idx_notion_pages_last_edit
-                    ON notion_pages(last_edited_at)
-                    """
-                )
+        conn.commit()
+        print("Estrutura neural construída com sucesso. O cérebro está pronto.")
 
-                # Tabela para commits do GitHub (Nossa Memória Processual)
-                cursor.execute(
-                    """
-                    CREATE TABLE IF NOT EXISTS github_commits (
-                        commit_hash TEXT PRIMARY KEY,
-                        repository TEXT NOT NULL,
-                        message TEXT,
-                        author TEXT,
-                        committed_at TIMESTAMP
-                    )
-                    """
-                )
+    except sqlite3.Error as e:
+        print(f"Erro catastrófico durante a Gênese: {e}")
+    finally:
+        if conn:
+            conn.close()
 
-                cursor.execute(
-                    """
-                    CREATE INDEX IF NOT EXISTS idx_github_commits_repository
-                    ON github_commits(repository)
-                    """
-                )
-
-                # Tabela de ligação (As Sinapses) - Antecipando a Fase 2.
-                cursor.execute(
-                    """
-                    CREATE TABLE IF NOT EXISTS knowledge_links (
-                        link_id INTEGER PRIMARY KEY AUTOINCREMENT,
-                        source_type TEXT NOT NULL, -- Ex: 'notion'
-                        source_id TEXT NOT NULL,   -- Ex: page_id
-                        target_type TEXT NOT NULL, -- Ex: 'github'
-                        target_id TEXT NOT NULL,   -- Ex: commit_hash
-                        relationship TEXT,         -- Ex: 'mentions', 'based_on'
-                        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-                    )
-                    """
-                )
-
-                cursor.execute(
-                    """
-                    CREATE UNIQUE INDEX IF NOT EXISTS idx_knowledge_links_uniqueness
-                    ON knowledge_links(source_type, source_id, target_type, target_id)
-                    """
-                )
-
-                conn.commit()
-                print("Estrutura neural construída com sucesso. O cérebro está pronto.")
-
-    except sqlite3.Error as exc:
-        print(f"Erro catastrófico durante a Gênese: {exc}")
-
-
-if __name__ == "__main__":
+if __name__ == '__main__':
     initialize_database()

--- a/sync_notion.py
+++ b/sync_notion.py
@@ -1,188 +1,101 @@
-"""Sincronização da memória consciente com o Notion."""
-
-from __future__ import annotations
-
-import hashlib
-import json
 import os
-import sqlite3
-from collections.abc import Generator, Iterable
-from contextlib import closing
-from typing import Any, Dict, Tuple
-
 import requests
-
+import sqlite3
+import json
+import hashlib
 from database import DB_FILE, initialize_database
 
-NOTION_VERSION = "2022-06-28"
-PAGE_SIZE = 100
-REQUEST_TIMEOUT = 30  # segundos
+# Carregar as credenciais de forma segura
+NOTION_API_KEY = os.environ.get('NOTION_API_KEY')
+NOTION_DATABASE_ID = os.environ.get('NOTION_DATABASE_ID')
 
+NOTION_API_URL = f"https://api.notion.com/v1/databases/{NOTION_DATABASE_ID}/query"
 
-def _environment_variables() -> Tuple[str | None, str | None]:
-    """Obtém as credenciais necessárias do ambiente."""
-
-    return os.environ.get("NOTION_API_KEY"), os.environ.get("NOTION_DATABASE_ID")
-
-
-def _build_session(api_key: str) -> requests.Session:
-    session = requests.Session()
-    session.headers.update(
-        {
-            "Authorization": f"Bearer {api_key}",
-            "Content-Type": "application/json",
-            "Notion-Version": NOTION_VERSION,
-        }
-    )
-    return session
-
-
-def _iter_title_candidates(title_list: Iterable[Dict[str, Any]] | None) -> Generator[str, None, None]:
-    if not title_list:
-        return
-    for item in title_list:
-        plain = item.get("plain_text")
-        if plain:
-            yield plain
-            continue
-        text = item.get("text", {})
-        content = text.get("content")
-        if content:
-            yield content
-
-
-def get_page_title(page_data: Dict[str, Any]) -> str:
-    """Extrai o título de uma página, lidando com variações de schema."""
-
-    properties = page_data.get("properties", {})
-    for prop_value in properties.values():
-        if prop_value.get("type") == "title":
-            for candidate in _iter_title_candidates(prop_value.get("title")):
-                return candidate.strip()
+def get_page_title(page_data):
+    """Extrai o título de uma página, lidando com possíveis variações de schema."""
+    properties = page_data.get('properties', {})
+    for prop_name, prop_value in properties.items():
+        if prop_value.get('type') == 'title':
+            title_list = prop_value.get('title')
+            if title_list:
+                return title_list[0].get('text', {}).get('content')
     return "Título não encontrado"
 
-
-def _compute_content_hash(page: Dict[str, Any]) -> Tuple[str, str]:
-    raw_data = json.dumps(page, sort_keys=True, ensure_ascii=False)
-    return raw_data, hashlib.sha256(raw_data.encode("utf-8")).hexdigest()
-
-
-def _notion_query(session: requests.Session, database_id: str, start_cursor: str | None) -> Dict[str, Any]:
-    payload: Dict[str, Any] = {"page_size": PAGE_SIZE}
-    if start_cursor:
-        payload["start_cursor"] = start_cursor
-
-    response = session.post(
-        f"https://api.notion.com/v1/databases/{database_id}/query",
-        json=payload,
-        timeout=REQUEST_TIMEOUT,
-    )
-    response.raise_for_status()
-    return response.json()
-
-
-def _fetch_all_pages(session: requests.Session, database_id: str) -> Generator[Dict[str, Any], None, None]:
-    start_cursor: str | None = None
-    while True:
-        page_data = _notion_query(session, database_id, start_cursor)
-        results = page_data.get("results", [])
-        for page in results:
-            yield page
-
-        if not page_data.get("has_more"):
-            break
-        start_cursor = page_data.get("next_cursor")
-        if not start_cursor:
-            break  # segurança extra contra loops infinitos
-
-
-def _persist_page(cursor: sqlite3.Cursor, page: Dict[str, Any]) -> Tuple[str, str]:
-    page_id = page["id"]
-    title = get_page_title(page)
-    created_at = page.get("created_time")
-    last_edited_at = page.get("last_edited_time")
-    notion_url = page.get("url")
-    raw_data, content_hash = _compute_content_hash(page)
-
-    cursor.execute("SELECT content_hash FROM notion_pages WHERE page_id = ?", (page_id,))
-    row = cursor.fetchone()
-    if row and row[0] == content_hash:
-        return "skipped", title
-
-    cursor.execute(
-        """
-        INSERT INTO notion_pages (page_id, title, content_hash, created_at, last_edited_at, notion_url, raw_data)
-        VALUES (?, ?, ?, ?, ?, ?, ?)
-        ON CONFLICT(page_id) DO UPDATE SET
-            title = excluded.title,
-            content_hash = excluded.content_hash,
-            last_edited_at = excluded.last_edited_at,
-            notion_url = excluded.notion_url,
-            raw_data = excluded.raw_data
-        """,
-        (page_id, title, content_hash, created_at, last_edited_at, notion_url, raw_data),
-    )
-
-    return ("created" if row is None else "updated"), title
-
-
-def sync_notion_pages(database_id: str | None = None, api_key: str | None = None) -> None:
-    """Ativa o sentido de percepção do Notion. Lê, processa e memoriza."""
-
-    api_key_env, database_id_env = _environment_variables()
-    api_key = api_key or api_key_env
-    database_id = database_id or database_id_env
-
-    if not api_key or not database_id:
-        print(
-            "ERRO CRÍTICO: As variáveis NOTION_API_KEY e NOTION_DATABASE_ID devem ser definidas nos Segredos."
-        )
+def sync_notion_pages():
+    """
+    Ativa o sentido de percepção do Notion. Lê, processa e memoriza.
+    """
+    if not NOTION_API_KEY or not NOTION_DATABASE_ID:
+        print("ERRO CRÍTICO: As variáveis NOTION_API_KEY e NOTION_DATABASE_ID devem ser definidas nos Segredos.")
         return
 
-    initialize_database()
-
-    created = updated = skipped = 0
-    processed_any = False
-
+    headers = {
+        "Authorization": f"Bearer {NOTION_API_KEY}",
+        "Content-Type": "application/json",
+        "Notion-Version": "2022-06-28"
+    }
+    
+    payload = {"page_size": 100}
+    
     try:
-        with _build_session(api_key) as session:
-            try:
-                with sqlite3.connect(DB_FILE) as conn:
-                    conn.row_factory = sqlite3.Row
-                    with closing(conn.cursor()) as cursor:
-                        print("Percepção ativada. Analisando unidades de conhecimento do Notion...")
-                        for page in _fetch_all_pages(session, database_id):
-                            processed_any = True
-                            action, title = _persist_page(cursor, page)
-                            if action == "created":
-                                created += 1
-                                print(f"  [+] Novo conhecimento detectado: '{title}'. Memorizando...")
-                            elif action == "updated":
-                                updated += 1
-                                print(f"  [~] Conhecimento modificado: '{title}'. Atualizando memória...")
-                            else:
-                                skipped += 1
-                        conn.commit()
-            except sqlite3.Error as exc:
-                print(f"Falha na memória interna (SQLite): {exc}")
-                return
-    except requests.exceptions.HTTPError as exc:
-        detail = exc.response.text if exc.response is not None else str(exc)
-        print(f"Falha de comunicação com o Córtex (Notion API): {detail}")
-        return
-    except requests.exceptions.RequestException as exc:
-        print(f"Falha de comunicação com o Córtex (Notion API): {exc}")
-        return
+        response = requests.post(NOTION_API_URL, headers=headers, json=payload)
+        response.raise_for_status() # Lança um erro para respostas HTTP > 400
+        data = response.json()
+        
+        pages = data.get('results', [])
+        if not pages:
+            print("Nenhuma página encontrada no banco de dados do Notion.")
+            return
 
-    if not processed_any:
-        print("Nenhuma página encontrada no banco de dados do Notion.")
-        return
+        conn = sqlite3.connect(DB_FILE)
+        cursor = conn.cursor()
+        
+        print(f"Percepção ativada. Analisando {len(pages)} unidades de conhecimento do Notion...")
+        
+        for page in pages:
+            page_id = page['id']
+            title = get_page_title(page)
+            created_at = page['created_time']
+            last_edited_at = page['last_edited_time']
+            notion_url = page['url']
+            
+            # Usamos o JSON completo para criar um hash robusto que detecta qualquer mudança.
+            raw_data_str = json.dumps(page, sort_keys=True)
+            content_hash = hashlib.sha256(raw_data_str.encode()).hexdigest()
+            
+            cursor.execute("SELECT content_hash FROM notion_pages WHERE page_id = ?", (page_id,))
+            result = cursor.fetchone()
+            
+            if result is None:
+                print(f"  [+] Novo conhecimento detectado: '{title}'. Memorizando...")
+                cursor.execute(
+                    """
+                    INSERT INTO notion_pages (page_id, title, content_hash, created_at, last_edited_at, notion_url, raw_data)
+                    VALUES (?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (page_id, title, content_hash, created_at, last_edited_at, notion_url, raw_data_str)
+                )
+            elif result[0] != content_hash:
+                print(f"  [~] Conhecimento modificado: '{title}'. Atualizando memória...")
+                cursor.execute(
+                    """
+                    UPDATE notion_pages
+                    SET title = ?, content_hash = ?, last_edited_at = ?, raw_data = ?
+                    WHERE page_id = ?
+                    """,
+                    (title, content_hash, last_edited_at, raw_data_str, page_id)
+                )
+        
+        conn.commit()
+        conn.close()
+        print("Sincronização da memória consciente (Notion) concluída.")
 
-    print(
-        "Sincronização da memória consciente (Notion) concluída. "
-        f"Novos: {created}, atualizados: {updated}, inalterados: {skipped}."
-    )
+    except requests.exceptions.RequestException as e:
+        print(f"Falha de comunicação com o Córtex (Notion API): {e}")
+    except sqlite3.Error as e:
+        print(f"Falha na memória interna (SQLite): {e}")
 
-
-if __name__ == "__main__":
+if __name__ == '__main__':
+    # Garante que a estrutura do cérebro existe antes de tentar usá-la.
+    initialize_database()
     sync_notion_pages()

--- a/sync_notion.py
+++ b/sync_notion.py
@@ -1,0 +1,188 @@
+"""Sincronização da memória consciente com o Notion."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import sqlite3
+from collections.abc import Generator, Iterable
+from contextlib import closing
+from typing import Any, Dict, Tuple
+
+import requests
+
+from database import DB_FILE, initialize_database
+
+NOTION_VERSION = "2022-06-28"
+PAGE_SIZE = 100
+REQUEST_TIMEOUT = 30  # segundos
+
+
+def _environment_variables() -> Tuple[str | None, str | None]:
+    """Obtém as credenciais necessárias do ambiente."""
+
+    return os.environ.get("NOTION_API_KEY"), os.environ.get("NOTION_DATABASE_ID")
+
+
+def _build_session(api_key: str) -> requests.Session:
+    session = requests.Session()
+    session.headers.update(
+        {
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+            "Notion-Version": NOTION_VERSION,
+        }
+    )
+    return session
+
+
+def _iter_title_candidates(title_list: Iterable[Dict[str, Any]] | None) -> Generator[str, None, None]:
+    if not title_list:
+        return
+    for item in title_list:
+        plain = item.get("plain_text")
+        if plain:
+            yield plain
+            continue
+        text = item.get("text", {})
+        content = text.get("content")
+        if content:
+            yield content
+
+
+def get_page_title(page_data: Dict[str, Any]) -> str:
+    """Extrai o título de uma página, lidando com variações de schema."""
+
+    properties = page_data.get("properties", {})
+    for prop_value in properties.values():
+        if prop_value.get("type") == "title":
+            for candidate in _iter_title_candidates(prop_value.get("title")):
+                return candidate.strip()
+    return "Título não encontrado"
+
+
+def _compute_content_hash(page: Dict[str, Any]) -> Tuple[str, str]:
+    raw_data = json.dumps(page, sort_keys=True, ensure_ascii=False)
+    return raw_data, hashlib.sha256(raw_data.encode("utf-8")).hexdigest()
+
+
+def _notion_query(session: requests.Session, database_id: str, start_cursor: str | None) -> Dict[str, Any]:
+    payload: Dict[str, Any] = {"page_size": PAGE_SIZE}
+    if start_cursor:
+        payload["start_cursor"] = start_cursor
+
+    response = session.post(
+        f"https://api.notion.com/v1/databases/{database_id}/query",
+        json=payload,
+        timeout=REQUEST_TIMEOUT,
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+def _fetch_all_pages(session: requests.Session, database_id: str) -> Generator[Dict[str, Any], None, None]:
+    start_cursor: str | None = None
+    while True:
+        page_data = _notion_query(session, database_id, start_cursor)
+        results = page_data.get("results", [])
+        for page in results:
+            yield page
+
+        if not page_data.get("has_more"):
+            break
+        start_cursor = page_data.get("next_cursor")
+        if not start_cursor:
+            break  # segurança extra contra loops infinitos
+
+
+def _persist_page(cursor: sqlite3.Cursor, page: Dict[str, Any]) -> Tuple[str, str]:
+    page_id = page["id"]
+    title = get_page_title(page)
+    created_at = page.get("created_time")
+    last_edited_at = page.get("last_edited_time")
+    notion_url = page.get("url")
+    raw_data, content_hash = _compute_content_hash(page)
+
+    cursor.execute("SELECT content_hash FROM notion_pages WHERE page_id = ?", (page_id,))
+    row = cursor.fetchone()
+    if row and row[0] == content_hash:
+        return "skipped", title
+
+    cursor.execute(
+        """
+        INSERT INTO notion_pages (page_id, title, content_hash, created_at, last_edited_at, notion_url, raw_data)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(page_id) DO UPDATE SET
+            title = excluded.title,
+            content_hash = excluded.content_hash,
+            last_edited_at = excluded.last_edited_at,
+            notion_url = excluded.notion_url,
+            raw_data = excluded.raw_data
+        """,
+        (page_id, title, content_hash, created_at, last_edited_at, notion_url, raw_data),
+    )
+
+    return ("created" if row is None else "updated"), title
+
+
+def sync_notion_pages(database_id: str | None = None, api_key: str | None = None) -> None:
+    """Ativa o sentido de percepção do Notion. Lê, processa e memoriza."""
+
+    api_key_env, database_id_env = _environment_variables()
+    api_key = api_key or api_key_env
+    database_id = database_id or database_id_env
+
+    if not api_key or not database_id:
+        print(
+            "ERRO CRÍTICO: As variáveis NOTION_API_KEY e NOTION_DATABASE_ID devem ser definidas nos Segredos."
+        )
+        return
+
+    initialize_database()
+
+    created = updated = skipped = 0
+    processed_any = False
+
+    try:
+        with _build_session(api_key) as session:
+            try:
+                with sqlite3.connect(DB_FILE) as conn:
+                    conn.row_factory = sqlite3.Row
+                    with closing(conn.cursor()) as cursor:
+                        print("Percepção ativada. Analisando unidades de conhecimento do Notion...")
+                        for page in _fetch_all_pages(session, database_id):
+                            processed_any = True
+                            action, title = _persist_page(cursor, page)
+                            if action == "created":
+                                created += 1
+                                print(f"  [+] Novo conhecimento detectado: '{title}'. Memorizando...")
+                            elif action == "updated":
+                                updated += 1
+                                print(f"  [~] Conhecimento modificado: '{title}'. Atualizando memória...")
+                            else:
+                                skipped += 1
+                        conn.commit()
+            except sqlite3.Error as exc:
+                print(f"Falha na memória interna (SQLite): {exc}")
+                return
+    except requests.exceptions.HTTPError as exc:
+        detail = exc.response.text if exc.response is not None else str(exc)
+        print(f"Falha de comunicação com o Córtex (Notion API): {detail}")
+        return
+    except requests.exceptions.RequestException as exc:
+        print(f"Falha de comunicação com o Córtex (Notion API): {exc}")
+        return
+
+    if not processed_any:
+        print("Nenhuma página encontrada no banco de dados do Notion.")
+        return
+
+    print(
+        "Sincronização da memória consciente (Notion) concluída. "
+        f"Novos: {created}, atualizados: {updated}, inalterados: {skipped}."
+    )
+
+
+if __name__ == "__main__":
+    sync_notion_pages()


### PR DESCRIPTION
## Summary
- harden the SQLite brain initialization with WAL, supporting indexes, and a uniqueness constraint for knowledge links
- stream the Notion synchronizer with pagination, smarter title extraction, and conflict-aware upserts
- ignore the generated v8-compile-cache-0 artefacts from version control

## Testing
- python3 database.py
- python3 sync_notion.py

------
https://chatgpt.com/codex/tasks/task_e_68ca133f4bdc832aa3fa534184174d4b